### PR TITLE
Correction typo Joomla en Joomla!

### DIFF
--- a/Installation-fr-FR/sql/mysql/joomla_fr.sql
+++ b/Installation-fr-FR/sql/mysql/joomla_fr.sql
@@ -1893,8 +1893,8 @@ CREATE TABLE IF NOT EXISTS `#__update_sites` (
 --
 
 INSERT INTO `#__update_sites` (`update_site_id`, `name`, `type`, `location`, `enabled`, `last_check_timestamp`) VALUES
-(1, 'Joomla Core', 'collection', 'http://update.joomla.org/core/list.xml', 1, 0),
-(2, 'Joomla Extension Directory', 'collection', 'http://update.joomla.org/jed/list.xml', 1, 0),
+(1, 'Joomla! Core', 'collection', 'http://update.joomla.org/core/list.xml', 1, 0),
+(2, 'Joomla! Extension Directory', 'collection', 'http://update.joomla.org/jed/list.xml', 1, 0),
 (3, 'Accredited Joomla! Translations', 'collection', 'http://update.joomla.org/language/translationlist_3.xml', 1, 0);
 
 -- --------------------------------------------------------


### PR DESCRIPTION
Correction typo modifiée pour Joomla --> Joomla!
"Joomla Core" --> "Joomla! Core"
"Joomla Extension Directory" --> "Joomla! Extension Directory"
